### PR TITLE
Speed up route lookup by grouping mappers by server names

### DIFF
--- a/app/discovery/discovery_test.go
+++ b/app/discovery/discovery_test.go
@@ -105,7 +105,7 @@ func TestService_Match(t *testing.T) {
 	err := svc.Run(ctx)
 	require.Error(t, err)
 	assert.Equal(t, context.DeadlineExceeded, err)
-	assert.Equal(t, 3, len(svc.mappers))
+	assert.Equal(t, 3, len(svc.Mappers()))
 
 	tbl := []struct {
 		server, src string


### PR DESCRIPTION
Addresses #4 by enumerating only subset of mappers where server name is either: exact match, empty string or * (wildcard).