### PR TITLE
Replaced github.com/pkg/errors with stdlib errors wrap

### DIFF
--- a/app/discovery/provider/file.go
+++ b/app/discovery/provider/file.go
@@ -2,13 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 	"sort"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/umputun/reproxy/app/discovery"
@@ -76,12 +76,12 @@ func (d *File) List() (res []discovery.URLMapper, err error) {
 	}
 	fh, err := os.Open(d.FileName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't open %s", d.FileName)
+		return nil, fmt.Errorf("can't open %s: %w", d.FileName, err)
 	}
 	defer fh.Close() //nolint gosec
 
 	if err = yaml.NewDecoder(fh).Decode(&fileConf); err != nil {
-		return nil, errors.Wrapf(err, "can't parse %s", d.FileName)
+		return nil, fmt.Errorf("can't parse %s: %w", d.FileName, err)
 	}
 	log.Printf("[DEBUG] file provider %+v", res)
 
@@ -89,7 +89,7 @@ func (d *File) List() (res []discovery.URLMapper, err error) {
 		for _, f := range fl {
 			rx, e := regexp.Compile(f.SourceRoute)
 			if e != nil {
-				return nil, errors.Wrapf(e, "can't parse regex %s", f.SourceRoute)
+				return nil, fmt.Errorf("can't parse regex %s: %w", f.SourceRoute, e)
 			}
 			if srv == "default" {
 				srv = "*"

--- a/app/discovery/provider/static.go
+++ b/app/discovery/provider/static.go
@@ -2,10 +2,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/umputun/reproxy/app/discovery"
 )
@@ -28,11 +27,11 @@ func (s *Static) List() (res []discovery.URLMapper, err error) {
 	parse := func(inp string) (discovery.URLMapper, error) {
 		elems := strings.Split(inp, ",")
 		if len(elems) != 4 {
-			return discovery.URLMapper{}, errors.Errorf("invalid rule %q", inp)
+			return discovery.URLMapper{}, fmt.Errorf("invalid rule %q", inp)
 		}
 		rx, err := regexp.Compile(strings.TrimSpace(elems[1]))
 		if err != nil {
-			return discovery.URLMapper{}, errors.Wrapf(err, "can't parse regex %s", elems[1])
+			return discovery.URLMapper{}, fmt.Errorf("can't parse regex %s: %w", elems[1], err)
 		}
 
 		return discovery.URLMapper{

--- a/app/main.go
+++ b/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	"github.com/umputun/go-flags"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -193,7 +193,7 @@ func makeProviders() ([]discovery.Provider, error) {
 	if opts.Docker.Enabled {
 		client, err := docker.NewClient(opts.Docker.Host)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to make docker client %s", err)
+			return nil, fmt.Errorf("failed to make docker client %w", err)
 		}
 		if opts.Docker.AutoAPI {
 			log.Printf("[INFO] auto-api enabled for docker")
@@ -203,7 +203,7 @@ func makeProviders() ([]discovery.Provider, error) {
 	}
 
 	if len(res) == 0 && opts.Assets.Location == "" {
-		return nil, errors.Errorf("no providers enabled")
+		return nil, errors.New("no providers enabled")
 	}
 	return res, nil
 }

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	R "github.com/go-pkgz/rest"
 	"github.com/go-pkgz/rest/logger"
 	"github.com/gorilla/handlers"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/reproxy/app/discovery"
 )
@@ -141,7 +141,7 @@ func (h *Http) Run(ctx context.Context) error {
 
 		return httpsServer.ListenAndServeTLS("", "")
 	}
-	return errors.Errorf("unknown SSL type %v", h.SSLConfig.SSLMode)
+	return fmt.Errorf("unknown SSL type %v", h.SSLConfig.SSLMode)
 }
 
 func (h *Http) proxyHandler() http.HandlerFunc {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-pkgz/lgr v0.10.4
 	github.com/go-pkgz/rest v1.9.1
 	github.com/gorilla/handlers v1.5.1
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/umputun/go-flags v1.5.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2

--- a/go.sum
+++ b/go.sum
@@ -45,10 +45,6 @@ github.com/fsouza/go-dockerclient v1.7.2 h1:bBEAcqLTkpq205jooP5RVroUKiVEWgGecHye
 github.com/fsouza/go-dockerclient v1.7.2/go.mod h1:+ugtMCVRwnPfY7d8/baCzZ3uwB0BrG5DB8OzbtxaRz8=
 github.com/go-pkgz/lgr v0.10.4 h1:l7qyFjqEZgwRgaQQSEp6tve4A3OU80VrfzpvtEX8ngw=
 github.com/go-pkgz/lgr v0.10.4/go.mod h1:CD0s1z6EFpIUplV067gitF77tn25JItzwHNKAPqeCF0=
-github.com/go-pkgz/rest v1.8.1 h1:M0sMbgcWxHpKjXw7Z8uF6uNcsLynaPoR0CHGczjYSw0=
-github.com/go-pkgz/rest v1.8.1/go.mod h1:wZ/dGipZUaF9to0vIQl7PwDHgWQDB0jsrFg1xnAKLDw=
-github.com/go-pkgz/rest v1.9.0 h1:cbBXd4YH0X6W64zneDGF+Ym3Mgj7Gv54krIEJjbQACs=
-github.com/go-pkgz/rest v1.9.0/go.mod h1:wZ/dGipZUaF9to0vIQl7PwDHgWQDB0jsrFg1xnAKLDw=
 github.com/go-pkgz/rest v1.9.1 h1:JW876BgJJ/MOkAYRnnzpfX7xUqIav+ou1LSVTtQq/Lo=
 github.com/go-pkgz/rest v1.9.1/go.mod h1:wZ/dGipZUaF9to0vIQl7PwDHgWQDB0jsrFg1xnAKLDw=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -90,8 +86,6 @@ github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
-github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -133,8 +127,6 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -153,7 +145,6 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -183,8 +174,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210216224549-f992740a1bac h1:9glrpwtNjBYgRpb67AZJKHfzj1stG/8BL5H7In2oTC4=
 golang.org/x/sys v0.0.0-20210216224549-f992740a1bac/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201113234701-d7a72108b828 h1:htWEtQEuEVJ4tU/Ngx7Cd/4Q7e3A5Up1owgyBtVsTwk=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -220,7 +211,6 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,6 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v0.1.1
 github.com/opencontainers/runc/libcontainer/user
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
Refs https://github.com/umputun/reproxy/issues/29

Replaces `github.com/pkg/errors` with stdlib capabilities for [wrapping errors](https://golang.org/doc/go1.13#error_wrapping).

Changes to `go.mod`, `go.sum` and `vendor/modules.txt` were made by `go mod tidy` run.

Package is not gone completely as it is implicitly required by docker-related dependencies.