### PR TITLE
Invoke Docker API directly

### DIFF
--- a/app/discovery/provider/docker_client_mock.go
+++ b/app/discovery/provider/docker_client_mock.go
@@ -5,8 +5,6 @@ package provider
 
 import (
 	"sync"
-
-	dclient "github.com/fsouza/go-dockerclient"
 )
 
 // DockerClientMock is a mock implementation of DockerClient.
@@ -15,10 +13,7 @@ import (
 //
 // 		// make and configure a mocked DockerClient
 // 		mockedDockerClient := &DockerClientMock{
-// 			AddEventListenerWithOptionsFunc: func(options dclient.EventsOptions, listener chan<- *dclient.APIEvents) error {
-// 				panic("mock out the AddEventListenerWithOptions method")
-// 			},
-// 			ListContainersFunc: func(opts dclient.ListContainersOptions) ([]dclient.APIContainers, error) {
+// 			ListContainersFunc: func() ([]containerInfo, error) {
 // 				panic("mock out the ListContainers method")
 // 			},
 // 		}
@@ -28,90 +23,37 @@ import (
 //
 // 	}
 type DockerClientMock struct {
-	// AddEventListenerWithOptionsFunc mocks the AddEventListenerWithOptions method.
-	AddEventListenerWithOptionsFunc func(options dclient.EventsOptions, listener chan<- *dclient.APIEvents) error
-
 	// ListContainersFunc mocks the ListContainers method.
-	ListContainersFunc func(opts dclient.ListContainersOptions) ([]dclient.APIContainers, error)
+	ListContainersFunc func() ([]containerInfo, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// AddEventListenerWithOptions holds details about calls to the AddEventListenerWithOptions method.
-		AddEventListenerWithOptions []struct {
-			// Options is the options argument value.
-			Options dclient.EventsOptions
-			// Listener is the listener argument value.
-			Listener chan<- *dclient.APIEvents
-		}
 		// ListContainers holds details about calls to the ListContainers method.
 		ListContainers []struct {
-			// Opts is the opts argument value.
-			Opts dclient.ListContainersOptions
 		}
 	}
-	lockAddEventListenerWithOptions sync.RWMutex
-	lockListContainers              sync.RWMutex
-}
-
-// AddEventListenerWithOptions calls AddEventListenerWithOptionsFunc.
-func (mock *DockerClientMock) AddEventListenerWithOptions(options dclient.EventsOptions, listener chan<- *dclient.APIEvents) error {
-	if mock.AddEventListenerWithOptionsFunc == nil {
-		panic("DockerClientMock.AddEventListenerWithOptionsFunc: method is nil but DockerClient.AddEventListenerWithOptions was just called")
-	}
-	callInfo := struct {
-		Options  dclient.EventsOptions
-		Listener chan<- *dclient.APIEvents
-	}{
-		Options:  options,
-		Listener: listener,
-	}
-	mock.lockAddEventListenerWithOptions.Lock()
-	mock.calls.AddEventListenerWithOptions = append(mock.calls.AddEventListenerWithOptions, callInfo)
-	mock.lockAddEventListenerWithOptions.Unlock()
-	return mock.AddEventListenerWithOptionsFunc(options, listener)
-}
-
-// AddEventListenerWithOptionsCalls gets all the calls that were made to AddEventListenerWithOptions.
-// Check the length with:
-//     len(mockedDockerClient.AddEventListenerWithOptionsCalls())
-func (mock *DockerClientMock) AddEventListenerWithOptionsCalls() []struct {
-	Options  dclient.EventsOptions
-	Listener chan<- *dclient.APIEvents
-} {
-	var calls []struct {
-		Options  dclient.EventsOptions
-		Listener chan<- *dclient.APIEvents
-	}
-	mock.lockAddEventListenerWithOptions.RLock()
-	calls = mock.calls.AddEventListenerWithOptions
-	mock.lockAddEventListenerWithOptions.RUnlock()
-	return calls
+	lockListContainers sync.RWMutex
 }
 
 // ListContainers calls ListContainersFunc.
-func (mock *DockerClientMock) ListContainers(opts dclient.ListContainersOptions) ([]dclient.APIContainers, error) {
+func (mock *DockerClientMock) ListContainers() ([]containerInfo, error) {
 	if mock.ListContainersFunc == nil {
 		panic("DockerClientMock.ListContainersFunc: method is nil but DockerClient.ListContainers was just called")
 	}
 	callInfo := struct {
-		Opts dclient.ListContainersOptions
-	}{
-		Opts: opts,
-	}
+	}{}
 	mock.lockListContainers.Lock()
 	mock.calls.ListContainers = append(mock.calls.ListContainers, callInfo)
 	mock.lockListContainers.Unlock()
-	return mock.ListContainersFunc(opts)
+	return mock.ListContainersFunc()
 }
 
 // ListContainersCalls gets all the calls that were made to ListContainers.
 // Check the length with:
 //     len(mockedDockerClient.ListContainersCalls())
 func (mock *DockerClientMock) ListContainersCalls() []struct {
-	Opts dclient.ListContainersOptions
 } {
 	var calls []struct {
-		Opts dclient.ListContainersOptions
 	}
 	mock.lockListContainers.RLock()
 	calls = mock.calls.ListContainers

--- a/app/discovery/provider/testdata/containers.json
+++ b/app/discovery/provider/testdata/containers.json
@@ -1,0 +1,91 @@
+[
+   {
+      "Id": "6f3c99ca4d83811ae1bf1c3e288ac229288028a8b097565cb93eed85ccc4c9b4",
+      "Names": [
+         "/nginx"
+      ],
+      "Image": "nginx",
+      "ImageID": "sha256:62d49f9bab67f7c70ac3395855bf01389eb3175b374e621f6f191bf31b54cd5b",
+      "Command": "/docker-entrypoint.sh nginx -g 'daemon off;'",
+      "Created": 1618417435,
+      "Ports": [
+         {
+            "PrivatePort": 80,
+            "Type": "tcp"
+         }
+      ],
+      "Labels": {
+         "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>",
+         "reproxy.enabled": "y"
+      },
+      "State": "running",
+      "Status": "Up 2 seconds",
+      "HostConfig": {
+         "NetworkMode": "default"
+      },
+      "NetworkSettings": {
+         "Networks": {
+            "bridge": {
+               "IPAMConfig": null,
+               "Links": null,
+               "Aliases": null,
+               "NetworkID": "7cf54d5b5b0cea56bcd4b5a8d7fd00ec6da9283a77e3cc0bd1252ebab60eca67",
+               "EndpointID": "481acb2624a95a12826357b1d6e9560ff0225b102ef932bb4dc484770f5b632b",
+               "Gateway": "172.17.0.1",
+               "IPAddress": "172.17.0.3",
+               "IPPrefixLen": 16,
+               "IPv6Gateway": "",
+               "GlobalIPv6Address": "",
+               "GlobalIPv6PrefixLen": 0,
+               "MacAddress": "02:42:42:42:42:03",
+               "DriverOpts": null
+            }
+         }
+      },
+      "Mounts": []
+   },
+   {
+      "Id": "d5503b81f356718bb01357daab63acb88eaae682bcb638383fadbac66e0bb830",
+      "Names": [
+         "/weather"
+      ],
+      "Image": "weather:latest",
+      "ImageID": "sha256:28ceada083a985a36f794904261b0a82d2c3be9de57076acab90ac304f77952e",
+      "Command": "/usr/local/bin/weather",
+      "Created": 1618410445,
+      "Ports": [
+         {
+            "PrivatePort": 8000,
+            "Type": "tcp"
+         }
+      ],
+      "Labels": {
+         "hello": "world"
+      },
+      "State": "running",
+      "Status": "Up 2 hours (healthy)",
+      "HostConfig": {
+         "NetworkMode": "default"
+      },
+      "NetworkSettings": {
+         "Networks": {
+            "someOtherNetwork": {
+               "IPAMConfig": null,
+               "Links": null,
+               "Aliases": null,
+               "NetworkID": "7cf54d5b5b0cea56bcd4b5a8d7fd00ec6da9283a77e3cc0bd1252ebab60eca67",
+               "EndpointID": "b4a14144a7300b37d4e907fdffa68b5234f67d2e7bb5db869198cf2db78d6280",
+               "Gateway": "172.17.0.1",
+               "IPAddress": "172.17.0.2",
+               "IPPrefixLen": 16,
+               "IPv6Gateway": "",
+               "GlobalIPv6Address": "",
+               "GlobalIPv6PrefixLen": 0,
+               "MacAddress": "02:42:42:42:42:02",
+               "DriverOpts": null
+            }
+         }
+      },
+      "Mounts": []
+   }
+]

--- a/app/main.go
+++ b/app/main.go
@@ -207,8 +207,11 @@ func makeProviders() ([]discovery.Provider, error) {
 		if opts.Docker.AutoAPI {
 			log.Printf("[INFO] auto-api enabled for docker")
 		}
+
+		const refreshInterval = time.Second * 10 // seems like a reasonable default
+
 		res = append(res, &provider.Docker{DockerClient: client, Excludes: opts.Docker.Excluded,
-			AutoAPI: opts.Docker.AutoAPI})
+			AutoAPI: opts.Docker.AutoAPI, RefreshInterval: refreshInterval})
 	}
 
 	if len(res) == 0 && opts.Assets.Location == "" {

--- a/app/main.go
+++ b/app/main.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/go-pkgz/lgr"
 	"github.com/umputun/go-flags"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -203,15 +202,13 @@ func makeProviders() ([]discovery.Provider, error) {
 	}
 
 	if opts.Docker.Enabled {
-		client, err := docker.NewClient(opts.Docker.Host)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make docker client %w", err)
-		}
+		client := provider.NewDockerClient(opts.Docker.Host, opts.Docker.Network)
+
 		if opts.Docker.AutoAPI {
 			log.Printf("[INFO] auto-api enabled for docker")
 		}
 		res = append(res, &provider.Docker{DockerClient: client, Excludes: opts.Docker.Excluded,
-			Network: opts.Docker.Network, AutoAPI: opts.Docker.AutoAPI})
+			AutoAPI: opts.Docker.AutoAPI})
 	}
 
 	if len(res) == 0 && opts.Assets.Location == "" {


### PR DESCRIPTION
Remove go-dockerclient dependency.
Now we poll for changes instead of subscribing to docker events, however I'm not sure if that covers all cases. Unfortunately docker does not expose container uptime so there is no easy way to detect restarts and other events. Can you test if desired use case still works?

closes #14
closes #22