### PR TITLE
Make anchor relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In addition to the common assets server multiple custom static servers supported
 - `--gzip` enables gizp compression for responses.
 - `--max=N` allows to set the maximum size of request (default 64k)
 - `--header` sets extra header(s) added to each proxied request
-- `--timeout.*` various timeouts for both server and proxy transport. See `timeout` section in [All Application Options](https://github.com/umputun/reproxy#all-application-options)
+- `--timeout.*` various timeouts for both server and proxy transport. See `timeout` section in [All Application Options](#all-application-options)
 
 ## Ping and health checks
 


### PR DESCRIPTION
Now when clicking on the link on the site we will be forward to GitHub repo.
GitHub supports relative anchors links as well as the site.