### PR TITLE
Fix a deadlock

### DIFF
--- a/app/proxy/health.go
+++ b/app/proxy/health.go
@@ -42,12 +42,11 @@ func (h *Http) healthHandler(w http.ResponseWriter, _ *http.Request) {
 			if m.PingURL == "" {
 				continue
 			}
-			sema <- struct{}{}
 			pinged++
 			wg.Add(1)
 
 			go func(m discovery.URLMapper) {
-
+				sema <- struct{}{}
 				defer func() {
 					<-sema
 					wg.Done()


### PR DESCRIPTION
Seems, there was a deadlock in healthHandler() if 2 * concurrent+1 goroutine tried to send message to outCh channel.