### PR TITLE
Mime cache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
     - varcheck
     - stylecheck
     - gochecknoinits
-    - scopelint
+    - exportloopref
     - gocritic
     - nakedret
     - gosimple

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ In addition to the common assets server, multiple custom static servers are supp
 
 Assets server supports caching control with the `--assets.cache=<duration>` parameter. `0s` duration (default) turns caching control off. A duration is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
+There are two ways to set cache duration:
+1. A single value for all static assets. This is as simple as `--assets.cache=48h`.
+2. Custom duration for different mime types. It should include two parts - the default value and the pairs of mime:duration. In command line this looks like multiple `--assets.cache` options, i.e. `--assets.cache=48h --assets.cache=text/html:24h --assets.cache=image/png:2h`. Environment values should be comma-separated, i.e.  `ASSETS_CACHE=48h,text/html:24h,image/png:2h`
+
 ## More options
 
 - `--gzip` enables gzip compression for responses.

--- a/app/main.go
+++ b/app/main.go
@@ -40,9 +40,9 @@ var opts struct {
 	} `group:"ssl" namespace:"ssl" env-namespace:"SSL"`
 
 	Assets struct {
-		Location      string        `short:"a" long:"location" env:"LOCATION" default:"" description:"assets location"`
-		WebRoot       string        `long:"root" env:"ROOT" default:"/" description:"assets web root"`
-		CacheDuration time.Duration `long:"cache" env:"CACHE" default:"0s" description:"cache duration for assets"`
+		Location     string   `short:"a" long:"location" env:"LOCATION" default:"" description:"assets location"`
+		WebRoot      string   `long:"root" env:"ROOT" default:"/" description:"assets web root"`
+		CacheControl []string `long:"cache" env:"CACHE" description:"cache duration for assets" env-delim:","`
 	} `group:"assets" namespace:"assets" env-namespace:"ASSETS"`
 
 	Logger struct {
@@ -153,7 +153,7 @@ func main() {
 		}
 	}()
 
-	metrcis := mgmt.NewMetrics()
+	metrics := mgmt.NewMetrics()
 	go func() {
 		mgSrv := mgmt.Server{
 			Listen:         opts.Management.Listen,
@@ -161,7 +161,7 @@ func main() {
 			AssetsLocation: opts.Assets.Location,
 			AssetsWebRoot:  opts.Assets.WebRoot,
 			Version:        revision,
-			Metrics:        metrcis,
+			Metrics:        metrics,
 		}
 		if opts.Management.Enabled {
 			if err := mgSrv.Run(ctx); err != nil {
@@ -170,20 +170,25 @@ func main() {
 		}
 	}()
 
+	cacheControl, err := proxy.MakeCacheControl(opts.Assets.CacheControl)
+	if err != nil {
+		log.Fatalf("[ERROR] failed to cache control, %v", err)
+	}
+
 	px := &proxy.Http{
-		Version:             revision,
-		Matcher:             svc,
-		Address:             opts.Listen,
-		MaxBodySize:         opts.MaxSize,
-		AssetsLocation:      opts.Assets.Location,
-		AssetsWebRoot:       opts.Assets.WebRoot,
-		AssetsCacheDuration: opts.Assets.CacheDuration,
-		GzEnabled:           opts.GzipEnabled,
-		SSLConfig:           sslConfig,
-		ProxyHeaders:        opts.ProxyHeaders,
-		AccessLog:           accessLog,
-		StdOutEnabled:       opts.Logger.StdOut,
-		Signature:           opts.Signature,
+		Version:        revision,
+		Matcher:        svc,
+		Address:        opts.Listen,
+		MaxBodySize:    opts.MaxSize,
+		AssetsLocation: opts.Assets.Location,
+		AssetsWebRoot:  opts.Assets.WebRoot,
+		CacheControl:   cacheControl,
+		GzEnabled:      opts.GzipEnabled,
+		SSLConfig:      sslConfig,
+		ProxyHeaders:   opts.ProxyHeaders,
+		AccessLog:      accessLog,
+		StdOutEnabled:  opts.Logger.StdOut,
+		Signature:      opts.Signature,
 		Timeouts: proxy.Timeouts{
 			ReadHeader:     opts.Timeouts.ReadHeader,
 			Write:          opts.Timeouts.Write,
@@ -195,7 +200,7 @@ func main() {
 			ExpectContinue: opts.Timeouts.ExpectContinue,
 			ResponseHeader: opts.Timeouts.ResponseHeader,
 		},
-		Metrics: metrcis,
+		Metrics: metrics,
 	}
 	if err := px.Run(ctx); err != nil {
 		if err == http.ErrServerClosed {

--- a/app/proxy/cache_control.go
+++ b/app/proxy/cache_control.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"fmt"
+	"mime"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CacheControl sets Cache-Control response header with different ages for different mimes
+type CacheControl struct {
+	defaultMaxAge time.Duration
+	maxAges       map[string]time.Duration
+}
+
+// NewCacheControl creates NewCacheControl with the default max age
+func NewCacheControl(defaultAge time.Duration) *CacheControl {
+	return &CacheControl{defaultMaxAge: defaultAge, maxAges: map[string]time.Duration{}}
+}
+
+// AddMime sets max age for a given mime
+func (c *CacheControl) AddMime(m string, d time.Duration) {
+	c.maxAges[m] = d
+}
+
+// Middleware checks if mime custom age set and returns it if matched to content type from resource (file) extension.
+// fallback to default if nothing matched
+func (c *CacheControl) Middleware(next http.Handler) http.Handler {
+
+	setMaxAgeHeader := func(age time.Duration, w http.ResponseWriter) {
+		w.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(int(age.Seconds())))
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if len(c.maxAges) == 0 && c.defaultMaxAge == 0 { // cache control disabled
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if len(c.maxAges) == 0 && c.defaultMaxAge > 0 {
+			setMaxAgeHeader(c.defaultMaxAge, w)
+			next.ServeHTTP(w, r)
+		}
+
+		ext := path.Ext(r.URL.Path) // the extension ext should begin with a leading dot, as in ".html"
+		if ext == "" {
+			ext = ".html"
+		}
+		mt := mime.TypeByExtension(ext)
+		if elems := strings.Split(mt, ";"); len(elems) > 1 { // strip suffix after ";", i.e. text/html; charset=utf-8
+			mt = strings.TrimSpace(elems[0])
+		}
+		val := c.defaultMaxAge
+		if v, ok := c.maxAges[mt]; ok {
+			val = v
+		}
+		setMaxAgeHeader(val, w)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// MakeCacheControl creates CacheControl from the list of params.
+// the first param represents default age and can be just a duration string (i.e. 60h) or "default:60h"
+// all other params are mime:duration pairs, i.e. "text/html:30s"
+func MakeCacheControl(cacheOpts []string) (*CacheControl, error) {
+	if len(cacheOpts) == 0 {
+		return NewCacheControl(0), nil
+	}
+	res := NewCacheControl(0)
+
+	// first elements may define default in both "10s" and "default:10s" forms
+	if !strings.Contains(cacheOpts[0], ":") { // single element, i.e 10s
+		dur, err := time.ParseDuration(cacheOpts[0])
+		if err != nil {
+			return nil, fmt.Errorf("can't parse default cache duration: %w", err)
+		}
+		res = NewCacheControl(dur)
+	}
+
+	if strings.Contains(cacheOpts[0], ":") { // two elements, i.e default:10s
+		elems := strings.Split(cacheOpts[0], ":")
+		if elems[0] != "default" {
+			return nil, fmt.Errorf("first cache duration has to be for the default mime")
+		}
+		dur, err := time.ParseDuration(elems[1])
+		if err != nil {
+			return nil, fmt.Errorf("can't parse default cache duration: %w", err)
+		}
+		res = NewCacheControl(dur)
+	}
+
+	// default only, no mime types
+	if len(cacheOpts) == 1 {
+		return res, nil
+	}
+
+	for _, v := range cacheOpts[1:] {
+		elems := strings.Split(v, ":")
+		if len(elems) != 2 {
+			return nil, fmt.Errorf("invalid mime:age entry %q", v)
+		}
+		dur, err := time.ParseDuration(elems[1])
+		if err != nil {
+			return nil, fmt.Errorf("can't parse cache duration from %s: %w", v, err)
+		}
+		res.AddMime(elems[0], dur)
+	}
+	return res, nil
+}

--- a/app/proxy/cache_control_test.go
+++ b/app/proxy/cache_control_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheControl_MiddlewareDefault(t *testing.T) {
+	req := httptest.NewRequest("GET", "/file.html", nil)
+	w := httptest.NewRecorder()
+
+	h := NewCacheControl(time.Hour).Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("something"))
+	}))
+	h.ServeHTTP(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "public, max-age=3600", resp.Header.Get("Cache-Control"))
+}
+
+func TestCacheControl_MiddlewareDisabled(t *testing.T) {
+	req := httptest.NewRequest("GET", "/file.html", nil)
+	w := httptest.NewRecorder()
+
+	h := NewCacheControl(0).Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("something"))
+	}))
+	h.ServeHTTP(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "", resp.Header.Get("Cache-Control"))
+}
+
+func TestCacheControl_MiddlewareMime(t *testing.T) {
+
+	cc := NewCacheControl(time.Hour)
+	cc.AddMime("text/html", time.Hour*2)
+	cc.AddMime("image/png", time.Hour*10)
+	h := cc.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("something"))
+	}))
+
+	{
+		req := httptest.NewRequest("GET", "/file.html", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "public, max-age=7200", resp.Header.Get("Cache-Control"), "match on .html")
+	}
+
+	{
+		req := httptest.NewRequest("GET", "/xyz/file.png?something=blah", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "public, max-age=36000", resp.Header.Get("Cache-Control"), "match on png")
+	}
+
+	{
+		req := httptest.NewRequest("GET", "/xyz/file.gif?something=blah", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "public, max-age=3600", resp.Header.Get("Cache-Control"), "no match, default")
+	}
+
+	{
+		req := httptest.NewRequest("GET", "/xyz/", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "public, max-age=7200", resp.Header.Get("Cache-Control"), "match on empty (index)")
+	}
+}
+
+func TestMakeCacheControl(t *testing.T) {
+
+	type mimeAge struct {
+		mime string
+		age  time.Duration
+	}
+
+	tbl := []struct {
+		opts     []string
+		defAge   time.Duration
+		mimeAges map[string]time.Duration
+		err      error
+	}{
+		{nil, time.Duration(0), nil, nil},
+		{[]string{"12h"}, 12 * time.Hour, nil, nil},
+		{[]string{"default:12h"}, 12 * time.Hour, nil, nil},
+		{[]string{"blah:12h"}, 0, nil, errors.New("first cache duration has to be for the default mime")},
+		{[]string{"a12bad"}, 0, nil, errors.New(`can't parse default cache duration: time: invalid duration "a12bad"`)},
+		{[]string{"default:a12bad"}, 0, nil, errors.New(`can't parse default cache duration: time: invalid duration "a12bad"`)},
+
+		{[]string{"12h", "text/html:10h", "image/png:6h"}, 12 * time.Hour,
+			map[string]time.Duration{"text/html": 10 * time.Hour, "image/png": 6 * time.Hour}, nil},
+		{[]string{"12h", "10h", "image/png:6h"}, 0, nil, errors.New(`invalid mime:age entry "10h"`)},
+		{[]string{"12h", "abc:10zzh", "image/png:6h"}, 0, nil,
+			errors.New(`can't parse cache duration from abc:10zzh: time: unknown unit "zzh" in duration "10zzh"`)},
+	}
+
+	for i, tt := range tbl {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			res, err := MakeCacheControl(tt.opts)
+			if tt.err != nil {
+				require.EqualError(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.defAge, res.defaultMaxAge)
+			for mime, age := range tt.mimeAges {
+				assert.Equal(t, age, res.maxAges[mime])
+			}
+			assert.Equal(t, len(tt.mimeAges), len(res.maxAges))
+		})
+	}
+
+}

--- a/app/proxy/cache_control_test.go
+++ b/app/proxy/cache_control_test.go
@@ -86,11 +86,6 @@ func TestCacheControl_MiddlewareMime(t *testing.T) {
 
 func TestMakeCacheControl(t *testing.T) {
 
-	type mimeAge struct {
-		mime string
-		age  time.Duration
-	}
-
 	tbl := []struct {
 		opts     []string
 		defAge   time.Duration


### PR DESCRIPTION
Adds support of multiple caches durations (per mime) in addition to the default one. Compatible with the prev assets.cache param #58 