### PR TITLE
simplify docker client constructor and add a minimal validation

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -243,7 +243,10 @@ func makeProviders() ([]discovery.Provider, error) {
 	}
 
 	if opts.Docker.Enabled {
-		client := provider.NewDockerClient(opts.Docker.Host, opts.Docker.Network)
+		client, err := provider.NewDockerClient(opts.Docker.Host, opts.Docker.Network)
+		if err != nil {
+			return nil, fmt.Errorf("can't make docker provider: %w", err)
+		}
 
 		if opts.Docker.AutoAPI {
 			log.Printf("[INFO] auto-api enabled for docker")


### PR DESCRIPTION
@holykol - I have changed your docker client constructor a little bit to get rid of regex parsing and also added some validation. Pls take a look and let me know what you think.
