### PR TITLE
Header comma

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -238,7 +238,7 @@ func run() error {
 		CacheControl:   cacheControl,
 		GzEnabled:      opts.GzipEnabled,
 		SSLConfig:      sslConfig,
-		ProxyHeaders:   opts.ProxyHeaders,
+		ProxyHeaders:   proxyHeaders,
 		AccessLog:      accessLog,
 		StdOutEnabled:  opts.Logger.StdOut,
 		Signature:      opts.Signature,

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -352,3 +352,27 @@ func (h *TestPlugin) ErrorThing(req lib.Request, res *lib.Response) (err error) 
 	res.StatusCode = 200
 	return nil
 }
+
+func Test_splitAtCommas(t *testing.T) {
+
+	tbl := []struct {
+		inp string
+		res []string
+	}{
+		{"a string", []string{"a string"}},
+		{"vv1, vv2, vv3", []string{"vv1", "vv2", "vv3"}},
+		{`"vv1, blah", vv2, vv3`, []string{"\"vv1, blah\"", "vv2", "vv3"}},
+		{
+			`Access-Control-Allow-Headers:"DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",header123:val, foo:"bar1,bar2"`,
+			[]string{"Access-Control-Allow-Headers:\"DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type\"", "header123:val", "foo:\"bar1,bar2\""},
+		},
+		{"", []string{}},
+	}
+
+	for i, tt := range tbl {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.res, splitAtCommas(tt.inp))
+		})
+	}
+
+}


### PR DESCRIPTION
Allows comma inside of quoted values in env, i.e. `HEADER=Access-Control-Allow-Headers:"DNT,X-CustomHeader",header123:val, foo:"bar1,bar2"` will be parsed as 3 headers:

- Access-Control-Allow-Headers:"DNT,X-CustomHeader"
- header123:val
-  foo:"bar1,bar2"

addresses #100 