### PR TITLE
make sure two consecutive Server calls return the same list of servers

### DIFF
--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -890,3 +890,27 @@ func TestHttp_matchHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestHttp_discoveredServers(t *testing.T) {
+
+	calls := 0
+	m := &MatcherMock{ServersFunc: func() []string {
+		defer func() { calls++ }()
+		switch calls {
+		case 0, 1, 2, 3, 4:
+			return []string{}
+		case 5:
+			return []string{"s1", "s2"}
+		case 6, 7:
+			return []string{"s1", "s2", "s3"}
+		default:
+			t.Fatalf("shoudn't be called %d times", calls)
+			return nil
+		}
+	}}
+
+	h := Http{Matcher: m}
+
+	res := h.discoveredServers(context.Background(), time.Millisecond)
+	assert.Equal(t, []string{"s1", "s2", "s3"}, res)
+}


### PR DESCRIPTION
The issue reported by @bobuk for the case with Auto SSL mode and an empty list of acme fqdns. In this case, reproxy uses the list of discovered servers as acme fqdns and the process is asynchronous, i.e. providers fill the list of servers in a separate goroutine.

The attempt to address is (see #63) didn't address the partial list of servers. This PR adds another check to make sure the list is "stable"

