### PR TITLE
Fix redirects

### DIFF
--- a/app/discovery/discovery.go
+++ b/app/discovery/discovery.go
@@ -392,7 +392,7 @@ func (s *Service) mergeLists() (res []URLMapper) {
 func (s *Service) extendMapper(m URLMapper) URLMapper {
 
 	src := m.SrcMatch.String()
-	m.Dst = strings.Replace(m.Dst, "@", "$", -1) // allow group defined as @n instead of $n (yaml friendly)
+	m.Dst = strings.ReplaceAll(m.Dst, "@", "$") // allow group defined as @n instead of $n (yaml friendly)
 
 	// static match with assets uses AssetsWebRoot and AssetsLocation
 	if m.MatchType == MTStatic && m.AssetsWebRoot != "" && m.AssetsLocation != "" {
@@ -421,24 +421,15 @@ func (s *Service) extendMapper(m URLMapper) URLMapper {
 		return m
 	}
 
-	res := URLMapper{
-		Server:         m.Server,
-		Dst:            strings.TrimSuffix(m.Dst, "/") + "/$1",
-		ProviderID:     m.ProviderID,
-		PingURL:        m.PingURL,
-		MatchType:      m.MatchType,
-		AssetsWebRoot:  m.AssetsWebRoot,
-		AssetsLocation: m.AssetsLocation,
-		AssetsSPA:      m.AssetsSPA,
-	}
+	m.Dst = strings.TrimSuffix(m.Dst, "/") + "/$1"
 
 	rx, err := regexp.Compile("^" + strings.TrimSuffix(src, "/") + "/(.*)")
 	if err != nil {
 		log.Printf("[WARN] can't extend %s, %v", m.SrcMatch.String(), err)
 		return m
 	}
-	res.SrcMatch = *rx
-	return res
+	m.SrcMatch = *rx
+	return m
 }
 
 // redirects process @code prefix and sets redirect type, i.e. "@302 /something"

--- a/app/discovery/discovery_test.go
+++ b/app/discovery/discovery_test.go
@@ -392,9 +392,9 @@ func TestService_extendRule(t *testing.T) {
 		},
 		{
 			URLMapper{Server: "m.example.com", PingURL: "http://example.com/ping", ProviderID: "docker",
-				SrcMatch: *regexp.MustCompile("/api/blah"), Dst: "http://localhost:8080/xxx"},
+				SrcMatch: *regexp.MustCompile("/api/blah"), Dst: "http://localhost:8080/xxx", RedirectType: RTPerm},
 			URLMapper{Server: "m.example.com", PingURL: "http://example.com/ping", ProviderID: "docker",
-				SrcMatch: *regexp.MustCompile("/api/blah"), Dst: "http://localhost:8080/xxx"},
+				SrcMatch: *regexp.MustCompile("/api/blah"), Dst: "http://localhost:8080/xxx", RedirectType: RTPerm},
 		},
 	}
 


### PR DESCRIPTION
Before this change redirects didn't work because method `Service.extendMapper` didn't copy the value of `URLMapper.RedirectType` to the extended result.

To fix this we return the original `URLMapper` instead of creating a new one (it can also help to avoid similar bugs in the future). We can reuse `URLMapper` because it is passed by value.