### PR TITLE
Skip SSL check for the destination host

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ supported codes:
 - `--gzip`   enables gzip compression for responses.
 - `--max=N`  allows to set the maximum size of request (default 64k). Setting it to `0` disables the size check.
 - `--timeout.*` various timeouts for both server and proxy transport. See `timeout` section in [All Application Options](#all-application-options). A zero or negative value means there will be no timeout.
+- `--insecure` disables SSL verification on the destination host. This is useful for the self-signed certificates.
 
 ## Default ports
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ This is the list of all options supporting multiple elements:
       --basic-htpasswd=             htpasswd file for basic auth [$BASIC_HTPASSWD]      
       --lb-type=[random|failover|roundrobin]   load balancer type (default: random) [$LB_TYPE]
       --signature                   enable reproxy signature headers [$SIGNATURE]
-      --remote-lookup-headers       enable remote lookup headers [$REMOTE_LOOKUP_HEADERS]      
+      --remote-lookup-headers       enable remote lookup headers [$REMOTE_LOOKUP_HEADERS]
+      --insecure                    skip SSL verification on destination host [$INSECURE]
       --dbg                         debug mode [$DEBUG]
 
 ssl:

--- a/app/main.go
+++ b/app/main.go
@@ -36,6 +36,7 @@ var opts struct {
 	AuthBasicHtpasswd   string   `long:"basic-htpasswd" env:"BASIC_HTPASSWD" description:"htpasswd file for basic auth"`
 	RemoteLookupHeaders bool     `long:"remote-lookup-headers" env:"REMOTE_LOOKUP_HEADERS" description:"enable remote lookup headers"`
 	LBType              string   `long:"lb-type" env:"LB_TYPE" description:"load balancer type" choice:"random" choice:"failover" choice:"roundrobin" default:"random"` // nolint
+	Insecure            bool     `long:"insecure" env:"INSECURE" description:"skip SSL certificate verification for the destination host"`
 
 	SSL struct {
 		Type          string   `long:"type" env:"TYPE" description:"ssl (auto) support" choice:"none" choice:"static" choice:"auto" default:"none"` // nolint
@@ -248,6 +249,7 @@ func run() error {
 		CacheControl:   cacheControl,
 		GzEnabled:      opts.GzipEnabled,
 		SSLConfig:      sslConfig,
+		Insecure:       opts.Insecure,
 		ProxyHeaders:   proxyHeaders,
 		DropHeader:     opts.DropHeaders,
 		AccessLog:      accessLog,

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -37,6 +38,7 @@ type Http struct { // nolint golint
 	ProxyHeaders     []string
 	DropHeader       []string
 	SSLConfig        SSLConfig
+	Insecure         bool
 	Version          string
 	AccessLog        io.Writer
 	StdOutEnabled    bool
@@ -223,6 +225,7 @@ func (h *Http) proxyHandler() http.HandlerFunc {
 			IdleConnTimeout:       h.Timeouts.IdleConn,
 			TLSHandshakeTimeout:   h.Timeouts.TLSHandshake,
 			ExpectContinueTimeout: h.Timeouts.ExpectContinue,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: h.Insecure},
 		},
 		ErrorLog: log.ToStdLogger(log.Default(), "WARN"),
 	}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -225,7 +225,7 @@ func (h *Http) proxyHandler() http.HandlerFunc {
 			IdleConnTimeout:       h.Timeouts.IdleConn,
 			TLSHandshakeTimeout:   h.Timeouts.TLSHandshake,
 			ExpectContinueTimeout: h.Timeouts.ExpectContinue,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: h.Insecure},
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: h.Insecure}, //nolint:gosec // G402: User defined option to disable verification for self-signed certificates
 		},
 		ErrorLog: log.ToStdLogger(log.Default(), "WARN"),
 	}


### PR DESCRIPTION
Related to https://github.com/umputun/reproxy/issues/162

Is it okay to use the option name "insecure"? Or should we use somtehing more explicit?