### PR TITLE
Reproxy Support for X-Forwarded Headers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ In case if rules set as a part of docker compose environment, destination with t
 
 ## SSL support
 
-SSL mode (by default none) can be set to `auto` (ACME/LE certificates), `static` (existing certificate) or `none`. If `auto` turned on SSL certificate will be issued automatically for all discovered server names. User can override it by setting `--ssl.fqdn` value(s)
+SSL mode (by default none) can be set to `auto` (ACME/LE certificates), `static` (existing certificate) or `none`. If `auto` turned on SSL certificate will be issued automatically for all discovered server names. User can override it by setting `--ssl.fqdn` value(s). In `auto` SSL mode, Reproxy will automatically add the `X-Forwarded-Proto` and `X-Forwarded-Port` headers. These headers are useful for services behind the proxy to know the original protocol (http or https) and port number used by the client.
 
 ## Headers 
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ In case if rules set as a part of docker compose environment, destination with t
 
 ## SSL support
 
-SSL mode (by default none) can be set to `auto` (ACME/LE certificates), `static` (existing certificate) or `none`. If `auto` turned on SSL certificate will be issued automatically for all discovered server names. User can override it by setting `--ssl.fqdn` value(s). In `auto` SSL mode, Reproxy will automatically add the `X-Forwarded-Proto` and `X-Forwarded-Port` headers. These headers are useful for services behind the proxy to know the original protocol (http or https) and port number used by the client.
+SSL mode (by default none) can be set to `auto` (ACME/LE certificates), `static` (existing certificate) or `none`. If `auto` turned on SSL certificate will be issued automatically for all discovered server names. User can override it by setting `--ssl.fqdn` value(s). In `auto` and `static` SSL mode, Reproxy will automatically add the `X-Forwarded-Proto` and `X-Forwarded-Port` headers. These headers are useful for services behind the proxy to know the original protocol (http or https) and port number used by the client.
 
 ## Headers 
 

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -212,7 +212,7 @@ func (h *Http) proxyHandler() http.HandlerFunc {
 			uu := ctx.Value(ctxURL).(*url.URL)
 			keepHost := ctx.Value(ctxKeepHost).(bool)
 			r.Header.Add("X-Forwarded-Host", r.Host)
-			if h.SSLConfig.SSLMode == SSLAuto {
+			if h.SSLConfig.SSLMode == SSLAuto || h.SSLConfig.SSLMode == SSLStatic {
 				r.Header.Add("X-Forwarded-Proto", "https")
 				r.Header.Add("X-Forwarded-Port", "443")
 			}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -212,6 +212,10 @@ func (h *Http) proxyHandler() http.HandlerFunc {
 			uu := ctx.Value(ctxURL).(*url.URL)
 			keepHost := ctx.Value(ctxKeepHost).(bool)
 			r.Header.Add("X-Forwarded-Host", r.Host)
+			if h.SSLConfig.SSLMode == SSLAuto {
+				r.Header.Add("X-Forwarded-Proto", "https")
+				r.Header.Add("X-Forwarded-Port", "443")
+			}
 			r.URL.Path = uu.Path
 			r.URL.Host = uu.Host
 			r.URL.Scheme = uu.Scheme

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -35,6 +35,8 @@ func TestHttp_Do(t *testing.T) {
 		w.Header().Add("h1", "v1")
 		require.Equal(t, "127.0.0.1", r.Header.Get("X-Real-IP"))
 		require.Equal(t, "127.0.0.1", r.Header.Get("X-Forwarded-For"))
+		require.Empty(t, r.Header.Get("X-Forwarded-Proto")) // ssl auto only
+		require.Empty(t, r.Header.Get("X-Forwarded-Port"))
 		fmt.Fprintf(w, "response %s", r.URL.String())
 	}))
 


### PR DESCRIPTION
Discussed here: https://github.com/umputun/reproxy/issues/172

Add the `X-Forwarded-Proto` and `X-Forwarded-Port` headers for SSLAuto mode.
