### PR TITLE
Update Docker Client API Version to Resolve Compatibility Issue

### DIFF
--- a/app/discovery/provider/docker.go
+++ b/app/discovery/provider/docker.go
@@ -373,7 +373,7 @@ func NewDockerClient(host, network string) DockerClient {
 func (d *dockerClient) ListContainers() ([]containerInfo, error) {
 	// Minimum API version that returns attached networks
 	// docs.docker.com/engine/api/version-history/#v122-api-changes
-	const APIVersion = "v1.22"
+	const APIVersion = "v1.24"
 
 	resp, err := d.client.Get(fmt.Sprintf("http://localhost/%s/containers/json", APIVersion))
 	if err != nil {

--- a/app/discovery/provider/docker_test.go
+++ b/app/discovery/provider/docker_test.go
@@ -369,7 +369,7 @@ func TestDocker_refresh(t *testing.T) {
 
 func TestDockerClient(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, `/v1.22/containers/json`, r.URL.Path)
+		require.Equal(t, `/v1.24/containers/json`, r.URL.Path)
 
 		// obtained using curl --unix-socket /var/run/docker.sock http://localhost/v1.41/containers/json
 		resp, err := os.ReadFile("testdata/containers.json")


### PR DESCRIPTION
This PR addresses the issue reported in https://github.com/umputun/reproxy/issues/171. 

We have encountered a compatibility problem due to the deprecation of the Docker client API version 1.22. The error message encountered is: "Client version 1.22 is too old. Minimum supported API version is 1.24."

To resolve this, I propose updating the Docker client API version to 1.24, which is the minimum supported version. This update ensures compatibility and aligns with the current Docker API standards.

For more details on the deprecated API versions, please refer to the Docker documentation: https://docs.docker.com/engine/api/#deprecated-api-versions.

