### PR TITLE
Add 'X-Forwarded-URL' to request header

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,12 @@ issues:
       linters:
         - gosec
         - dupl
+    - linters:
+        - unparam
+        - unused
+        - revive
+      path: _test\.go$
+      text: "unused-parameter"
   exclude-use-default: false
 
 service:

--- a/app/main.go
+++ b/app/main.go
@@ -358,7 +358,7 @@ func makePluginConductor(ctx context.Context) proxy.MiddlewareProvider {
 
 	conductor := &plugin.Conductor{
 		Address: opts.Plugin.Listen,
-		RPCDialer: plugin.RPCDialerFunc(func(network, address string) (plugin.RPCClient, error) {
+		RPCDialer: plugin.RPCDialerFunc(func(_, address string) (plugin.RPCClient, error) {
 			return rpc.Dial("tcp", address)
 		}),
 	}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -353,7 +353,7 @@ func (h *Http) matchHandler(next http.Handler) http.Handler {
 
 func (h *Http) assetsHandler() http.HandlerFunc {
 	if h.AssetsLocation == "" || h.AssetsWebRoot == "" {
-		return func(writer http.ResponseWriter, request *http.Request) {}
+		return func(_ http.ResponseWriter, _ *http.Request) {}
 	}
 
 	var notFound []byte
@@ -371,7 +371,7 @@ func (h *Http) assetsHandler() http.HandlerFunc {
 	fs, err := h.fileServer(h.AssetsWebRoot, h.AssetsLocation, h.AssetsSPA, notFound)
 	if err != nil {
 		log.Printf("[WARN] can't initialize assets server, %v", err)
-		return func(writer http.ResponseWriter, request *http.Request) {}
+		return func(_ http.ResponseWriter, _ *http.Request) {}
 	}
 	return h.CacheControl.Middleware(fs).ServeHTTP
 }

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -212,6 +212,7 @@ func (h *Http) proxyHandler() http.HandlerFunc {
 			uu := ctx.Value(ctxURL).(*url.URL)
 			keepHost := ctx.Value(ctxKeepHost).(bool)
 			r.Header.Add("X-Forwarded-Host", r.Host)
+			r.Header.Set("X-Forwarded-URL", r.URL.String())
 			if h.SSLConfig.SSLMode == SSLAuto || h.SSLConfig.SSLMode == SSLStatic {
 				h.setHeaderIfNotExists(r, "X-Forwarded-Proto", "https")
 				h.setHeaderIfNotExists(r, "X-Forwarded-Port", "443")

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -39,6 +39,7 @@ func TestHttp_Do(t *testing.T) {
 		require.Equal(t, "127.0.0.1", r.Header.Get("X-Forwarded-For"))
 		require.Empty(t, r.Header.Get("X-Forwarded-Proto")) // ssl auto only
 		require.Empty(t, r.Header.Get("X-Forwarded-Port"))
+		require.NotEmpty(t, r.Header.Get("X-Forwarded-URL"), "X-Forwarded-URL header must be set")
 		fmt.Fprintf(w, "response %s", r.URL.String())
 	}))
 
@@ -65,7 +66,7 @@ func TestHttp_Do(t *testing.T) {
 	client := http.Client{}
 
 	t.Run("to 127.0.0.1, good", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://127.0.0.1:"+strconv.Itoa(port)+"/api/something", http.NoBody)
+		req, err := http.NewRequest("GET", "http://127.0.0.1:"+strconv.Itoa(port)+"/api/something?xxx=yyy", http.NoBody)
 		require.NoError(t, err)
 		resp, err := client.Do(req)
 		require.NoError(t, err)
@@ -75,7 +76,7 @@ func TestHttp_Do(t *testing.T) {
 
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		assert.Equal(t, "response /567/something", string(body))
+		assert.Equal(t, "response /567/something?xxx=yyy", string(body))
 		assert.Equal(t, "reproxy", resp.Header.Get("App-Name"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 		assert.Equal(t, "vv1", resp.Header.Get("hh1"))


### PR DESCRIPTION
The request header now has 'X-Forwarded-URL'. This is particularly useful if we deal with a chain of reverse proxy requests and the final destination has to discover the URL that was passed in originally.

The header is `Set`, not `Add`.  Most scenarios with `X-Forwarded-URL` I can think of, involve setting it to reflect the current request's URL, so `Set` is likely the appropriate choice to ensure no duplicate headers convey conflicting information.

