### PR TITLE
Added support for ACME directory switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For convenience, requests with the trailing `/` and without regex groups expande
 
 The host substitution is supported in the destination URL. For example, `/files/${host}` will be replaced with the matched host name. `$host` (without braces) can also be used.
 
-Both HTTP and HTTPS supported. For HTTPS, static certificate can be used as well as automated ACME (Let's Encrypt) certificates. Optional assets server can be used to serve static files. Starting reproxy requires at least one provider defined. The rest of parameters are strictly optional and have sane default.
+Both HTTP and HTTPS supported. For HTTPS, static certificate can be used as well as automated ACME (Let's Encrypt or compatible) certificates. Optional assets server can be used to serve static files. Starting reproxy requires at least one provider defined. The rest of parameters are strictly optional and have sane default.
 
 Examples:
 
@@ -383,6 +383,7 @@ ssl:
       --ssl.cert=                   path to cert.pem file [$SSL_CERT]
       --ssl.key=                    path to key.pem file [$SSL_KEY]
       --ssl.acme-location=          dir where certificates will be stored by autocert manager (default: ./var/acme) [$SSL_ACME_LOCATION]
+      --ssl.acme-directory=         acme directory url [$SSL_ACME_DITRCTORY]
       --ssl.acme-email=             admin email for certificate notifications [$SSL_ACME_EMAIL]
       --ssl.http-port=              http port for redirect to https and acme challenge test (default: 8080 under docker, 80 without) [$SSL_HTTP_PORT]
       --ssl.fqdn=                   FQDN(s) for ACME certificates [$SSL_ACME_FQDN]

--- a/app/main.go
+++ b/app/main.go
@@ -43,6 +43,7 @@ var opts struct {
 		Type          string   `long:"type" env:"TYPE" description:"ssl (auto) support" choice:"none" choice:"static" choice:"auto" default:"none"` // nolint
 		Cert          string   `long:"cert" env:"CERT" description:"path to cert.pem file"`
 		Key           string   `long:"key" env:"KEY" description:"path to key.pem file"`
+		ACMEDirectoru string   `long:"acme-directory" env:"ACME_DITRCTORY" description:"acme directory url"`
 		ACMELocation  string   `long:"acme-location" env:"ACME_LOCATION" description:"dir where certificates will be stored by autocert manager" default:"./var/acme"`
 		ACMEEmail     string   `long:"acme-email" env:"ACME_EMAIL" description:"admin email for certificate notifications"`
 		RedirHTTPPort int      `long:"http-port" env:"HTTP_PORT" description:"http port for redirect to https and acme challenge test (default: 8080 under docker, 80 without)"`


### PR DESCRIPTION
For now, reproxy only allows the use of the default ACME directory, which is https://acme-v02.api.letsencrypt.org/directory.

With these changes, users can change the directory to any other. It can be LE staging environment (see https://letsencrypt.org/docs/staging-environment/) or even other compatible ACME provider, e.g. zerossl.