### PR TITLE
fix(proxy): bound RoundRobinSelector return to current n (#250)

### DIFF
--- a/app/proxy/handlers_test.go
+++ b/app/proxy/handlers_test.go
@@ -124,9 +124,9 @@ func Test_signatureHandler(t *testing.T) {
 
 func Test_limiterSystemHandler(t *testing.T) {
 
-	var passed int32
+	var passed atomic.Int32
 	handler := limiterSystemHandler(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&passed, 1)
+		passed.Add(1)
 	}))
 
 	ts := httptest.NewServer(handler)
@@ -146,14 +146,14 @@ func Test_limiterSystemHandler(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	assert.Equal(t, int32(10), atomic.LoadInt32(&passed))
+	assert.Equal(t, int32(10), passed.Load())
 }
 
 func Test_limiterClientHandlerNoMatches(t *testing.T) {
 
-	var passed int32
+	var passed atomic.Int32
 	handler := limiterUserHandler(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&passed, 1)
+		passed.Add(1)
 	}))
 
 	ts := httptest.NewServer(handler)
@@ -173,19 +173,19 @@ func Test_limiterClientHandlerNoMatches(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	assert.Equal(t, int32(10), atomic.LoadInt32(&passed))
+	assert.Equal(t, int32(10), passed.Load())
 }
 
 func Test_limiterClientHandlerWithMatches(t *testing.T) {
-	var passed int32
+	var passed atomic.Int32
 	handler := limiterUserHandler(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&passed, 1)
+		passed.Add(1)
 	}))
 
 	wrapWithContext := func(next http.Handler) http.Handler {
-		var id int32
+		var id atomic.Int32
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			n := int(atomic.AddInt32(&id, 1))
+			n := int(id.Add(1))
 			m := discovery.MatchedRoute{Mapper: discovery.URLMapper{Dst: strconv.Itoa(n % 2)}}
 			ctx := context.WithValue(context.Background(), ctxMatchType, discovery.MTProxy)
 			ctx = context.WithValue(ctx, ctxMatch, m)
@@ -214,7 +214,7 @@ func Test_limiterClientHandlerWithMatches(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	assert.Equal(t, int32(20), atomic.LoadInt32(&passed))
+	assert.Equal(t, int32(20), passed.Load())
 }
 
 func TestHttp_basicAuthHandler(t *testing.T) {

--- a/app/proxy/lb_selector.go
+++ b/app/proxy/lb_selector.go
@@ -15,8 +15,10 @@ type RoundRobinSelector struct {
 func (r *RoundRobinSelector) Select(n int) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	selected := r.lastSelected
-	r.lastSelected = (r.lastSelected + 1) % n
+	// bound to current n: alive-backend count can shrink between calls
+	// (health-check flips), so the previously stored index may be out of range
+	selected := r.lastSelected % n
+	r.lastSelected = selected + 1
 	return selected
 }
 

--- a/app/proxy/lb_selector.go
+++ b/app/proxy/lb_selector.go
@@ -18,7 +18,7 @@ func (r *RoundRobinSelector) Select(n int) int {
 	// bound to current n: alive-backend count can shrink between calls
 	// (health-check flips), so the previously stored index may be out of range
 	selected := r.lastSelected % n
-	r.lastSelected = selected + 1
+	r.lastSelected = (selected + 1) % n
 	return selected
 }
 

--- a/app/proxy/lb_selector_test.go
+++ b/app/proxy/lb_selector_test.go
@@ -29,6 +29,22 @@ func TestRoundRobinSelector_Select(t *testing.T) {
 	}
 }
 
+func TestRoundRobinSelector_SelectShrinkingN(t *testing.T) {
+	// reproduces issue #250: when the alive-backend count shrinks between calls
+	// (e.g. a backend health-check flips dead), the stale lastSelected can exceed
+	// the new n, causing matchHandler to index out of range and panic.
+	selector := &RoundRobinSelector{}
+
+	// advance internal state with n=3 so the next return position is 2
+	assert.Equal(t, 0, selector.Select(3))
+	assert.Equal(t, 1, selector.Select(3))
+
+	// one backend goes unhealthy: n shrinks to 2. result must remain a valid index.
+	got := selector.Select(2)
+	assert.GreaterOrEqual(t, got, 0)
+	assert.Less(t, got, 2, "Select(2) returned %d, out of range for slice of length 2", got)
+}
+
 func TestRoundRobinSelector_SelectConcurrent(t *testing.T) {
 	selector := &RoundRobinSelector{}
 	l := 3

--- a/app/proxy/lb_selector_test.go
+++ b/app/proxy/lb_selector_test.go
@@ -29,6 +29,21 @@ func TestRoundRobinSelector_Select(t *testing.T) {
 	}
 }
 
+func TestRoundRobinSelector_SelectGrowingN(t *testing.T) {
+	// verifies the [0, n) invariant on lastSelected: after completing a cycle
+	// with small n, a subsequent call with larger n must restart from 0 rather
+	// than continuing the stale counter (e.g., dead backend recovers).
+	selector := &RoundRobinSelector{}
+
+	assert.Equal(t, 0, selector.Select(3))
+	assert.Equal(t, 1, selector.Select(3))
+	assert.Equal(t, 2, selector.Select(3))
+
+	// n grows from 3 to 5; lastSelected wrapped to 0 on the previous call.
+	assert.Equal(t, 0, selector.Select(5))
+	assert.Equal(t, 1, selector.Select(5))
+}
+
 func TestRoundRobinSelector_SelectShrinkingN(t *testing.T) {
 	// reproduces issue #250: when the alive-backend count shrinks between calls
 	// (e.g. a backend health-check flips dead), the stale lastSelected can exceed

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -1011,10 +1011,10 @@ func TestHttp_matchHandler(t *testing.T) {
 		},
 	}
 
-	var count int32
+	var count atomic.Int32
 	matcherMock := &MatcherMock{
 		MatchFunc: func(srv string, src string) discovery.Matches {
-			return tbl[atomic.LoadInt32(&count)].matches
+			return tbl[count.Load()].matches
 		},
 	}
 
@@ -1037,7 +1037,7 @@ func TestHttp_matchHandler(t *testing.T) {
 			wr := httptest.NewRecorder()
 			handler.ServeHTTP(wr, req)
 			assert.Equal(t, http.StatusOK, wr.Code)
-			atomic.AddInt32(&count, 1)
+			count.Add(1)
 		})
 	}
 }

--- a/app/proxy/ssl.go
+++ b/app/proxy/ssl.go
@@ -87,7 +87,11 @@ func (h *Http) redirectHandler() http.Handler {
 		if r.URL.RawQuery != "" {
 			newURL += "?" + r.URL.RawQuery
 		}
-		http.Redirect(w, r, newURL, http.StatusTemporaryRedirect) //nolint:gosec // standard http->https upgrade, redirect target derived from request host
+		// standard http->https upgrade: redirect target is built from the request Host header,
+		// matching the pattern used by Go's autocert HTTPHandler, nginx, Caddy. Browsers send Host
+		// based on URL hostname, so an attacker cannot make a victim's browser send a foreign Host
+		// to redirect them elsewhere; a self-spoofed Host only redirects the spoofer to themselves.
+		http.Redirect(w, r, newURL, http.StatusTemporaryRedirect) //nolint:gosec // see comment above
 	})
 }
 

--- a/app/proxy/ssl.go
+++ b/app/proxy/ssl.go
@@ -87,7 +87,7 @@ func (h *Http) redirectHandler() http.Handler {
 		if r.URL.RawQuery != "" {
 			newURL += "?" + r.URL.RawQuery
 		}
-		http.Redirect(w, r, newURL, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, newURL, http.StatusTemporaryRedirect) //nolint:gosec // standard http->https upgrade, redirect target derived from request host
 	})
 }
 

--- a/lib/plugin_test.go
+++ b/lib/plugin_test.go
@@ -16,14 +16,14 @@ import (
 
 func TestPlugin_Do(t *testing.T) {
 
-	var postCalls int32
-	var deleteCalls int32
+	var postCalls atomic.Int32
+	var deleteCalls atomic.Int32
 	tsConductor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "POST":
-			atomic.AddInt32(&postCalls, 1)
+			postCalls.Add(1)
 		case "DELETE":
-			atomic.AddInt32(&deleteCalls, 1)
+			deleteCalls.Add(1)
 		default:
 			t.Fatalf("unexpected method %s", r.Method)
 		}
@@ -39,8 +39,8 @@ func TestPlugin_Do(t *testing.T) {
 	defer cancel()
 	err = p.Do(ctx, "http://"+u.Host, new(TestingHandler))
 	require.EqualError(t, err, "context done: context deadline exceeded")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&postCalls))
-	assert.Equal(t, int32(1), atomic.LoadInt32(&deleteCalls))
+	assert.Equal(t, int32(1), postCalls.Load())
+	assert.Equal(t, int32(1), deleteCalls.Load())
 }
 
 func TestPlugin_DoFailed(t *testing.T) {


### PR DESCRIPTION
Fixes the panic reported in #250. `RoundRobinSelector.Select` returned the un-bounded stale `lastSelected`, applying modulo only to the next iteration's seed. When the alive-backend count shrinks between calls (a backend health-check flips dead), the stored index can exceed the new `n`, and `matchHandler` indexes out of range in `proxy.go:352`.

**Repro:** call `Select(3)` twice (returns 0, then 1, leaves `lastSelected=2`), then `Select(2)` returns 2 into a 2-element slice. Exact match to the reporter's `index out of range [2] with length 2`.

**Fix:** apply modulo to `lastSelected` before returning, so `Select` is always in `[0, n)` regardless of how the previous call left the state. First-call-returns-0 behavior preserved.

**Tests:** added `TestRoundRobinSelector_SelectShrinkingN` covering the shrinking-n path. Existing tests still pass, race detector clean.

*History:* the bug shipped in commit fa23778d (2023-11-27) and was live across v1.1.0 through v1.5.0, ~2.5 years. Existing tests only called `Select` with constant `n`, so the path was never exercised. Round-robin is opt-in via `--lb-type=roundrobin`, default is random which doesn't hit this code.

**Cleanup commit:** also addresses 6 pre-existing lint findings unrelated to the fix - replaces `int32`+`sync/atomic` free functions with `atomic.Int32` in test files (modernize/atomictypes), and adds an inline `//nolint:gosec` with explanation on the standard http->https redirect handler (G710 taint analysis false positive, redirect target derives from request host).

Related to #250
