### PR TITLE
Fix load balancing on catch-all server broken by default-route dedup

### DIFF
--- a/app/discovery/discovery.go
+++ b/app/discovery/discovery.go
@@ -168,6 +168,21 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 }
 
+// isDefaultServer reports whether server is the catch-all/default server key ("*" or "")
+func isDefaultServer(server string) bool {
+	return server == "*" || server == ""
+}
+
+// hasConcreteRoute reports whether any route is served by a concrete (non-default) server
+func hasConcreteRoute(routes []MatchedRoute) bool {
+	for _, r := range routes {
+		if !isDefaultServer(r.Mapper.Server) {
+			return true
+		}
+	}
+	return false
+}
+
 // Match url to all mappers. Returns Matches with potentially multiple destinations for MTProxy.
 // For MTStatic always a single match because fail-over doesn't supported for assets
 func (s *Service) Match(srv, src string) (res Matches) {
@@ -181,6 +196,25 @@ func (s *Service) Match(srv, src string) (res Matches) {
 		return dest
 	}
 
+	// if the match returns both default (catch-all) and concrete server routes, drop the default ones as the
+	// concrete server is a better match. if every matched route is on the default server keep them all, multiple
+	// routes for the same source on the catch-all server is a legit load-balancing setup.
+	dropDefaultsIfConcrete := func(routes []MatchedRoute) []MatchedRoute {
+		if len(routes) <= 1 {
+			return routes
+		}
+		concrete := make([]MatchedRoute, 0, len(routes))
+		for _, r := range routes {
+			if !isDefaultServer(r.Mapper.Server) {
+				concrete = append(concrete, r)
+			}
+		}
+		if len(concrete) > 0 && len(concrete) < len(routes) {
+			return concrete
+		}
+		return routes
+	}
+
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -188,8 +222,10 @@ func (s *Service) Match(srv, src string) (res Matches) {
 	for _, srvName := range []string{srv, "*", ""} {
 		for _, m := range s.findMatchingMappers(srvName) {
 
-			// if the first match found and the next src match is not identical we can stop as src match regexes presorted
+			// if the first match found and the next src match is not identical we can stop as src match regexes presorted.
+			// filter default routes here too, this early return otherwise bypasses the post-loop dedup below
 			if len(res.Routes) > 0 && m.SrcMatch.String() != lastSrcMatch {
+				res.Routes = dropDefaultsIfConcrete(res.Routes)
 				return res
 			}
 
@@ -208,6 +244,13 @@ func (s *Service) Match(srv, src string) (res Matches) {
 					wr += "/"
 				}
 				if src == m.AssetsWebRoot || strings.HasPrefix(src, wr) {
+					// a default-server assets route must not override a concrete server match found in
+					// an earlier bucket; return the concrete match instead of appending the catch-all
+					// assets (this branch returns directly and would otherwise skip the dedup below)
+					if isDefaultServer(m.Server) && hasConcreteRoute(res.Routes) {
+						res.Routes = dropDefaultsIfConcrete(res.Routes)
+						return res
+					}
 					res.MatchType = MTStatic
 					destSfx := ":norm"
 					if m.AssetsSPA {
@@ -221,16 +264,7 @@ func (s *Service) Match(srv, src string) (res Matches) {
 		}
 	}
 
-	// if match returns both default and concrete server(s), drop default as we have a better match with concrete
-	if len(res.Routes) > 1 {
-		for i := range res.Routes {
-			if res.Routes[i].Mapper.Server == "*" || res.Routes[i].Mapper.Server == "" {
-				res.Routes = append(res.Routes[:i], res.Routes[i+1:]...)
-				break
-			}
-		}
-	}
-
+	res.Routes = dropDefaultsIfConcrete(res.Routes)
 	return res
 }
 
@@ -256,7 +290,7 @@ func (s *Service) findMatchingMappers(srvName string) []URLMapper {
 
 	for mapperServer, mapper := range s.mappers {
 		// * and "" should not be treated as regex and require exact match (above)
-		if mapperServer == "*" || mapperServer == "" {
+		if isDefaultServer(mapperServer) {
 			continue
 		}
 
@@ -325,7 +359,7 @@ func (s *Service) Servers() (servers []string) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	for key, ms := range s.mappers {
-		if key == "*" || key == "" {
+		if isDefaultServer(key) {
 			continue
 		}
 		for _, m := range ms {

--- a/app/discovery/discovery_test.go
+++ b/app/discovery/discovery_test.go
@@ -546,6 +546,162 @@ func TestService_Match192(t *testing.T) {
 	}
 }
 
+// multiple routes for the same source on the catch-all server is a load-balancing setup,
+// all of them should be returned when no concrete server matched
+func TestService_MatchCatchAllLoadBalancing(t *testing.T) {
+	p1 := &ProviderMock{
+		EventsFunc: func(ctx context.Context) <-chan ProviderID {
+			res := make(chan ProviderID, 1)
+			res <- PIFile
+			return res
+		},
+		ListFunc: func() ([]URLMapper, error) {
+			return []URLMapper{
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"),
+					Dst: "http://127.0.0.1:8080/$1", ProviderID: PIFile},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"),
+					Dst: "http://127.0.0.2:8080/$1", ProviderID: PIFile},
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/api/(.*)"),
+					Dst: "http://127.0.0.3:8080/$1", ProviderID: PIFile},
+			}, nil
+		},
+	}
+
+	svc := NewService([]Provider{p1}, time.Millisecond*100)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := svc.Run(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Len(t, svc.Mappers(), 3)
+
+	tbl := []struct {
+		name, server, src string
+		dests             []string
+	}{
+		{"both catch-all routes returned for unknown server", "some.example.ru", "/api/thing",
+			[]string{"http://127.0.0.1:8080/thing", "http://127.0.0.2:8080/thing"}},
+		{"concrete server drops catch-all routes", "example.com", "/api/thing",
+			[]string{"http://127.0.0.3:8080/thing"}},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			res := svc.Match(tt.server, tt.src)
+			require.Len(t, res.Routes, len(tt.dests), res.Routes)
+			dests := make([]string, 0, len(res.Routes))
+			for _, r := range res.Routes {
+				assert.True(t, r.Alive)
+				dests = append(dests, r.Destination)
+			}
+			assert.ElementsMatch(t, tt.dests, dests)
+			assert.Equal(t, MTProxy, res.MatchType)
+		})
+	}
+}
+
+// matchTestService builds a Service populated with the given mappers, ready for Match calls.
+func matchTestService(t *testing.T, mappers []URLMapper) *Service {
+	t.Helper()
+	p := &ProviderMock{
+		EventsFunc: func(_ context.Context) <-chan ProviderID {
+			res := make(chan ProviderID, 1)
+			res <- PIFile
+			return res
+		},
+		ListFunc: func() ([]URLMapper, error) { return mappers, nil },
+	}
+	svc := NewService([]Provider{p}, 20*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	t.Cleanup(cancel)
+	require.ErrorIs(t, svc.Run(ctx), context.DeadlineExceeded)
+	return svc
+}
+
+// a concrete server match must drop same-source default routes at every return point of Match:
+// the presorted-src early return (a shorter default src following the matched one), the end-of-loop
+// dedup, and the MTStatic branch's own early return. all-default matches keep every route so
+// catch-all load balancing is preserved.
+func TestService_MatchDefaultConcreteDedup(t *testing.T) {
+	tbl := []struct {
+		name        string
+		mappers     []URLMapper
+		server, src string
+		wantDests   []string
+		wantType    MatchType
+	}{
+		{
+			name: "concrete drops star default via early return",
+			mappers: []URLMapper{
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://concrete:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://star:8080/$1"},
+				// shorter default src, sorts after the matched one and triggers the early return
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/(.*)"), Dst: "http://star-root:8080/$1"},
+			},
+			server: "example.com", src: "/api/thing",
+			wantDests: []string{"http://concrete:8080/thing"}, wantType: MTProxy,
+		},
+		{
+			name: "concrete drops empty-server default via end-of-loop dedup",
+			mappers: []URLMapper{
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://concrete:8080/$1"},
+				{Server: "", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://empty:8080/$1"},
+			},
+			server: "example.com", src: "/api/thing",
+			wantDests: []string{"http://concrete:8080/thing"}, wantType: MTProxy,
+		},
+		{
+			name: "multiple concretes survive, defaults dropped",
+			mappers: []URLMapper{
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://c1:8080/$1"},
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://c2:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://star:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/(.*)"), Dst: "http://star-root:8080/$1"},
+			},
+			server: "example.com", src: "/api/thing",
+			wantDests: []string{"http://c1:8080/thing", "http://c2:8080/thing"}, wantType: MTProxy,
+		},
+		{
+			name: "all-default load balancing preserved via early return",
+			mappers: []URLMapper{
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://star1:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/api/(.*)"), Dst: "http://star2:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/(.*)"), Dst: "http://star-root:8080/$1"},
+			},
+			server: "unknown.example.com", src: "/api/thing",
+			wantDests: []string{"http://star1:8080/thing", "http://star2:8080/thing"}, wantType: MTProxy,
+		},
+		{
+			name: "concrete proxy drops catch-all static (MTStatic branch)",
+			mappers: []URLMapper{
+				{Server: "example.com", SrcMatch: *regexp.MustCompile("^/(.*)"), Dst: "http://concrete:8080/$1"},
+				{Server: "*", SrcMatch: *regexp.MustCompile("^/(.*)"), Dst: "/var/web",
+					MatchType: MTStatic, AssetsWebRoot: "/", AssetsLocation: "/var/web"},
+			},
+			server: "example.com", src: "/foo",
+			wantDests: []string{"http://concrete:8080/foo"}, wantType: MTProxy,
+		},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range tt.mappers {
+				tt.mappers[i].ProviderID = PIFile
+			}
+			svc := matchTestService(t, tt.mappers)
+			res := svc.Match(tt.server, tt.src)
+			require.Len(t, res.Routes, len(tt.wantDests), res.Routes)
+			dests := make([]string, 0, len(res.Routes))
+			for _, r := range res.Routes {
+				dests = append(dests, r.Destination)
+			}
+			assert.ElementsMatch(t, tt.wantDests, dests)
+			assert.Equal(t, tt.wantType, res.MatchType)
+		})
+	}
+}
+
 func TestService_Servers(t *testing.T) {
 	p1 := &ProviderMock{
 		EventsFunc: func(ctx context.Context) <-chan ProviderID {


### PR DESCRIPTION
Previously, the dedup added for #192 removed a default-server route from the match result whenever more than one route matched, without checking that a concrete-server route was actually present. With multiple routes for the same source on the catch-all (`*` / default) server — the documented load-balancing setup — one route was silently dropped, so traffic always went to a single backend and failover could return 502 while a healthy backend still existed. When several default routes matched alongside a concrete one, only the first default route was removed.

The dedup also ran only at the end of the match loop, so the presorted-src early return (triggered by a shorter default `src` following the matched one) bypassed it entirely and leaked a catch-all route alongside the concrete match.

After this change, the default/concrete dedup is a single helper applied at both the early return and the final return: default-server routes are dropped only when at least one concrete server route matched, all of them are dropped in that case, and a match consisting solely of default-server routes keeps every route so catch-all load balancing and failover work as documented.

Added `TestService_MatchCatchAllLoadBalancing` (all catch-all routes kept for an unknown server, catch-all dropped when a concrete server matches) and `TestService_MatchConcreteDropsDefaultOnEarlyReturn` (covers the early-return path and both `*` and `""` default server keys). Both fail against the old logic and pass with the fix.
